### PR TITLE
Fix/issue 3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 2.0.1 (05/06/2020) 
 - fixed issues with "amount left" sometimes displaying wrong decimal values
+- fixed issues with error message that appeared sometimes on startup
 
 2.0.0 (05/06/2020) 
 - Overhauled UI

--- a/src/services/storage/storage.ts
+++ b/src/services/storage/storage.ts
@@ -20,7 +20,7 @@ const get = async () => {
   }
 
   return {
-    ...(items && { items }),
+    items: items || [],
     ...(metadata && { ...metadata }),
   } as StorageData;
 };


### PR DESCRIPTION
If the user didn't create an expense on the first time using the app, every other time he opened the app without having any items an error would popup because was trying to update items redux state with undefined.

This fixes it 