### PR TITLE
Fix/month handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@react-navigation/material-top-tabs": "^5.2.9",
     "@react-navigation/native": "^5.5.0",
     "@react-navigation/stack": "^5.4.1",
-    "dayjs": "^1.8.28",
     "nanoid": "^3.1.9",
     "react": "16.11.0",
     "react-hook-form": "^5.7.2",

--- a/src/components/MonthSelector/MonthSelector.tsx
+++ b/src/components/MonthSelector/MonthSelector.tsx
@@ -9,14 +9,14 @@ import {
 import Icon from "react-native-vector-icons/Ionicons";
 
 import MonthSelectorItem from "../MonthSelectorItem";
-import { Month } from "../../types";
-import { months } from "../../utils";
 import { i18nContext } from "../../contexts/i18n";
 
 interface Props {
-  selectedMonths: Month[];
-  updateSelected: (months: Month[]) => void;
+  selectedMonths: number[];
+  updateSelected: (months: number[]) => void;
 }
+
+const months = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
 export default function MonthSelector({
   selectedMonths,
@@ -27,11 +27,11 @@ export default function MonthSelector({
   const [maxHeight, setMaxHeight] = useState<number>(-1);
   const { i18n } = useContext(i18nContext);
 
-  const onUnselect = (id: number) => {
-    updateSelected(selectedMonths.filter((item) => item.id !== id));
+  const onUnselect = (month: number) => {
+    updateSelected(selectedMonths.filter((item) => item !== month));
   };
 
-  const onSelect = (month: Month) => {
+  const onSelect = (month: number) => {
     updateSelected([...selectedMonths, month]);
   };
 
@@ -78,10 +78,10 @@ export default function MonthSelector({
       <View style={styles.monthWrapper}>
         {months.map((m) => (
           <MonthSelectorItem
-            key={m.id}
-            label={m.label}
-            initialSelected={!!selectedMonths.find(({ id }) => id === m.id)}
-            onUnselect={() => onUnselect(m.id)}
+            key={m}
+            label={i18n.monthNames[m]}
+            initialSelected={!!selectedMonths.includes(m)}
+            onUnselect={() => onUnselect(m)}
             onSelect={() => onSelect(m)}
           />
         ))}

--- a/src/components/MonthSelector/index.ts
+++ b/src/components/MonthSelector/index.ts
@@ -2,7 +2,6 @@ import { connect } from "react-redux";
 
 import MonthSelector from "./MonthSelector";
 import { StoreState } from "../../types/store";
-import { Month } from "../../types";
 import { updateSelectedMonths } from "../../store/actions/current";
 
 const mapStateToProps = (state: StoreState) => ({
@@ -10,7 +9,7 @@ const mapStateToProps = (state: StoreState) => ({
 });
 
 const mapDispatchtoProps = (dispatch: Function) => ({
-  updateSelected: (payload: Month[]) => {
+  updateSelected: (payload: number[]) => {
     return dispatch(updateSelectedMonths(payload));
   },
 });

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -4,13 +4,13 @@ import { getStatusBarHeight } from "react-native-status-bar-height";
 
 interface Props {
   children?: any;
-  title: string;
+  title?: string;
 }
 
 export default function TopBar({ children, title }: Props) {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
+      {!!title && <Text style={styles.title}>{title}</Text>}
       {children}
     </View>
   );

--- a/src/i18n/en_GB.ts
+++ b/src/i18n/en_GB.ts
@@ -46,4 +46,18 @@ export default {
   webviewLoadErr:
     "An error ocurred trying to load the file. \n\nTry again later and if the issue persists, please contact us",
   currency: "Currency",
+  monthNames: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ],
 };

--- a/src/i18n/pt_PT.ts
+++ b/src/i18n/pt_PT.ts
@@ -46,4 +46,18 @@ export default {
   webviewLoadErr:
     "Ocorreu um erro ao tentar carregar o ficheiro. \n\nTente novamente mais tarde e se o problema persistir por favor entre em contacto connosco",
   currency: "Moeda",
+  monthNames: [
+    "Janeiro",
+    "Fevereiro",
+    "Março",
+    "Abril",
+    "Maio",
+    "Junho",
+    "Julho",
+    "Agosto",
+    "Setembro",
+    "Outubro",
+    "Novemmbro",
+    "Dezembro",
+  ],
 };

--- a/src/screens/AllExpenses/AllExpenses.tsx
+++ b/src/screens/AllExpenses/AllExpenses.tsx
@@ -9,12 +9,7 @@ import {
 import { useNavigation } from "@react-navigation/native";
 
 import { TopBar, List, ListItem } from "../../components";
-import {
-  Item,
-  Month,
-  RenderItemParams,
-  SupportedCurrencies,
-} from "../../types";
+import { Item, RenderItemParams, SupportedCurrencies } from "../../types";
 import { i18nContext } from "../../contexts/i18n";
 
 interface Props {
@@ -22,7 +17,7 @@ interface Props {
   currCurrency: SupportedCurrencies;
   reorderItems: (items: Item[]) => void;
   updateCurrent: (item?: Item) => void;
-  removeItem: (id: string, months: Month[], amount: number) => void;
+  removeItem: (id: string, months: number[], amount: number) => void;
 }
 
 export default function AllExpenses({
@@ -66,14 +61,14 @@ export default function AllExpenses({
     );
   };
 
-  const renderMonths = (months: Month[]) => {
+  const renderMonths = (months: number[]) => {
     if (!months.length || months.length === 12) {
       return <Text style={styles.tag}>{i18n.monthlyExpense}</Text>;
     }
 
     return months.map((m) => (
-      <Text key={m.id} style={styles.tag}>
-        {m.label}
+      <Text key={m} style={styles.tag}>
+        {i18n.monthNames[m]}
       </Text>
     ));
   };

--- a/src/screens/AllExpenses/index.ts
+++ b/src/screens/AllExpenses/index.ts
@@ -2,7 +2,7 @@ import { connect } from "react-redux";
 
 import component from "./AllExpenses";
 import { StoreState } from "../../types/store";
-import { Item, Month } from "../../types";
+import { Item } from "../../types";
 import { updateSelected } from "../../store/actions/current";
 import { removeItem, setItems } from "../../store/actions/items";
 import { subtractAmount } from "../../store/actions/amountLeft";
@@ -16,7 +16,7 @@ const mapStateToProps = ({ items, currency }: StoreState) => ({
 const mapDispatchToProps = (dispatch: Function) => ({
   updateCurrent: (item?: Item) => dispatch(updateSelected(item)),
   reorderItems: (items: Item[]) => dispatch(setItems(items)),
-  removeItem: (id: string, months: Month[], amount: number) => {
+  removeItem: (id: string, months: number[], amount: number) => {
     dispatch(removeItem(id));
 
     if (isCurrentMonth(months)) {

--- a/src/screens/ExpenseForm/ExpenseForm.tsx
+++ b/src/screens/ExpenseForm/ExpenseForm.tsx
@@ -13,17 +13,17 @@ import { useForm } from "react-hook-form";
 import { useNavigation } from "@react-navigation/native";
 import Icon from "react-native-vector-icons/Ionicons";
 
-import { Item, Month, ItemCreation } from "../../types";
+import { Item, ItemCreation } from "../../types";
 import { TopBar, FormItem, MonthSelector } from "../../components";
 import { getPlatformIcon } from "../../utils";
 import { i18nContext } from "../../contexts/i18n";
 
 interface Props {
   item: Item | null;
-  selectedMonths: Month[];
+  selectedMonths: number[];
   create: (item: ItemCreation) => void;
   update: (item: Item, amount: number) => void;
-  remove: (id: string, months: Month[], amount: number) => void;
+  remove: (id: string, months: number[], amount: number) => void;
 }
 
 interface Form {

--- a/src/screens/ExpenseForm/index.ts
+++ b/src/screens/ExpenseForm/index.ts
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import component from "./ExpenseForm";
 import { StoreState } from "../../types/store";
 import { addItem, updateItem, removeItem } from "../../store/actions/items";
-import { Item, ItemCreation, Month } from "../../types";
+import { Item, ItemCreation } from "../../types";
 import { addAmount, subtractAmount } from "../../store/actions/amountLeft";
 import { isCurrentMonth } from "../../utils";
 
@@ -34,7 +34,7 @@ const mapDispatchToProps = (dispatch: Function) => {
         dispatch(subtractAmount(oldAmount));
       }
     },
-    remove: (id: string, months: Month[], amount: number) => {
+    remove: (id: string, months: number[], amount: number) => {
       dispatch(removeItem(id));
 
       if (isCurrentMonth(months)) {

--- a/src/screens/MonthlyExpenses/MonthlyExpenses.tsx
+++ b/src/screens/MonthlyExpenses/MonthlyExpenses.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { View, Text, StyleSheet } from "react-native";
-import dayjs from "dayjs";
 import Emoji from "react-native-emoji";
 
 import { List, TopBar, ListItem } from "../../components";
@@ -31,6 +30,12 @@ export default function MonthlyExpenses({
     updateAmountLeft(amount, isPaid);
   };
 
+  const getTitle = () => {
+    const d = new Date();
+
+    return `${i18n.monthNames[d.getMonth()]} ${d.getFullYear()}`;
+  };
+
   const renderItem = (props: RenderItemParams) => {
     return (
       <ListItem
@@ -57,7 +62,7 @@ export default function MonthlyExpenses({
 
   return (
     <View style={styles.container}>
-      <TopBar title={dayjs().format("MMMM YYYY")}>
+      <TopBar title={getTitle()}>
         <Text style={styles.leftover}>
           {i18n.amountLeft(amountLeft, currCurrency)}
         </Text>

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -18,6 +18,25 @@ type StorageKey = "items" | "metadata" | "locale" | "currency";
 
 const key = "MPT_DATA";
 
+// backwards compatible fix. If months on items were in the old way, formats them to new way
+// added in v2.1.0, to remove asap
+const handleItems = (items: string) => {
+  if (!items) {
+    return [];
+  }
+
+  const newItems: Item[] = JSON.parse(items).map((item: Item) => ({
+    ...item,
+    months: item.months.map((m: any) => {
+      return typeof m === "number" ? m : m.id;
+    }),
+  }));
+
+  set("items", newItems);
+
+  return newItems;
+};
+
 const get = async (): Promise<StorageData> => {
   const [items, metadata, currency] = await Promise.all([
     storage.getItem(`${key}_items`),
@@ -30,7 +49,7 @@ const get = async (): Promise<StorageData> => {
   }
 
   return {
-    items: JSON.parse(items) || [],
+    items: handleItems(items),
     currency: currency || SupportedCurrencies.EUR,
     ...(metadata && { ...JSON.parse(metadata) }),
   };

--- a/src/store/actions/current.ts
+++ b/src/store/actions/current.ts
@@ -1,12 +1,12 @@
-import { UPDATE_SELECTED_ITEM, UPDATE_SELECTED_MONTHS } from './types';
-import { Item, Month } from '../../types';
+import { UPDATE_SELECTED_ITEM, UPDATE_SELECTED_MONTHS } from "./types";
+import { Item } from "../../types";
 
 export const updateSelected = (payload?: Item) => ({
   type: UPDATE_SELECTED_ITEM,
   payload,
 });
 
-export const updateSelectedMonths = (payload: Month[]) => ({
+export const updateSelectedMonths = (payload: number[]) => ({
   type: UPDATE_SELECTED_MONTHS,
   payload,
 });

--- a/src/store/reducers/current.ts
+++ b/src/store/reducers/current.ts
@@ -3,7 +3,7 @@ import { ReducerAction } from "../../types/store";
 import { Item } from "../../types";
 
 interface State {
-  months: Item[];
+  months: number[];
   item: Item;
 }
 
@@ -14,7 +14,7 @@ const initState: State = {
 
 export default (
   state = initState,
-  { type, payload }: ReducerAction<Item | Item[]>,
+  { type, payload }: ReducerAction<Item | Item[] | number[]>,
 ) => {
   switch (type) {
     case UPDATE_SELECTED_MONTHS: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 export interface ItemCreation {
   description: string;
   amount: number;
-  months: Month[];
+  months: number[];
 }
 
 export interface Item extends ItemCreation {
@@ -14,11 +14,6 @@ export interface StorageData {
   currMonth: number;
   items: Item[];
   currency: SupportedCurrencies;
-}
-
-export interface Month {
-  id: number;
-  label: string;
 }
 
 export interface RenderItemParams {

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,10 +1,10 @@
-import { Item, Month, SupportedCurrencies } from "./";
+import { Item, SupportedCurrencies } from "./";
 
 export interface StoreState {
   items: Item[];
   current: {
     item: Item;
-    months: Month[];
+    months: number[];
   };
   amountLeft: number;
   currency: SupportedCurrencies;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,22 +1,6 @@
 import { Platform } from "react-native";
 
-import { Month } from "../types";
 import { formatCurrency, formatDecimal } from "./formatters";
-
-export const months = [
-  { id: 0, label: "January" },
-  { id: 1, label: "February" },
-  { id: 2, label: "March" },
-  { id: 3, label: "April" },
-  { id: 4, label: "May" },
-  { id: 5, label: "June" },
-  { id: 6, label: "July" },
-  { id: 7, label: "August" },
-  { id: 8, label: "September" },
-  { id: 9, label: "October" },
-  { id: 10, label: "November" },
-  { id: 11, label: "December" },
-];
 
 export const sanitizeAmount = (amount: any) => {
   try {
@@ -28,14 +12,10 @@ export const sanitizeAmount = (amount: any) => {
   }
 };
 
-export const isCurrentMonth = (months: Month[]) => {
+export const isCurrentMonth = (months: number[]) => {
   const m = new Date().getMonth();
 
-  return (
-    !months.length ||
-    months.length === 11 ||
-    !!months.find(({ id }) => id === m)
-  );
+  return !months.length || months.length === 11 || !months.includes(m);
 };
 
 export const getPlatformIcon = (name: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,7 +2435,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dayjs@^1.8.15, dayjs@^1.8.28:
+dayjs@^1.8.15:
   version "1.8.28"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.28.tgz#37aa6201df483d089645cb6c8f6cef6f0c4dbc07"
   integrity sha512-ccnYgKC0/hPSGXxj7Ju6AV/BP4HUkXC2u15mikXT5mX9YorEaoi1bEKOmAqdkJHN4EEkmAf97SpH66Try5Mbeg==


### PR DESCRIPTION
- now months are a number[] instead of {id, label} object (as it should've been from the beginning)
	- added backwards compatibility so this won't be an issue for current users
- updated monthlyExpesnes screen title to use i18n for month name
