### PR TITLE
Fix/i18n handling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { NativeModules, Platform } from "react-native";
 import { Provider } from "react-redux";
+import SplashScreen from "react-native-splash-screen";
 
 import store from "./src/store";
 import locales from "./src/i18n";
@@ -20,6 +21,7 @@ export default function App() {
 
     if (locale in SupportedLocales) {
       setI18n(locales[locale as SupportedLocales]);
+      SplashScreen.hide();
       return;
     }
 
@@ -29,7 +31,7 @@ export default function App() {
           setI18n(locales[locale]);
         }
       })
-    });
+      .finally(() => SplashScreen.hide());
   }, []);
 
   const getDeviceLocale = (): string | undefined => {

--- a/App.tsx
+++ b/App.tsx
@@ -16,22 +16,34 @@ export default function App() {
   const i18nProviderValue = useMemo(() => ({ i18n, setI18n }), [i18n]);
 
   useEffect(() => {
-    const locale =
-      Platform.OS === "ios"
-        ? NativeModules.SettingsManager.settings.AppleLocale
-        : NativeModules.I18nManager.localeIdentifier;
+    const locale = getDeviceLocale();
 
     if (locale in SupportedLocales) {
       setI18n(locales[locale as SupportedLocales]);
       return;
     }
 
-    getLocale().then((locale) => {
-      if (locale) {
-        setI18n(locales[locale]);
-      }
+    getLocale()
+      .then((locale) => {
+        if (locale) {
+          setI18n(locales[locale]);
+        }
+      })
     });
   }, []);
+
+  const getDeviceLocale = (): string | undefined => {
+    const locale =
+      Platform.OS === "ios"
+        ? NativeModules.SettingsManager.settings.AppleLocale
+        : NativeModules.I18nManager.localeIdentifier;
+
+    if (!locale) {
+      return undefined;
+    }
+
+    return locale.split("_")[0];
+  };
 
   const onLocaleSelect = (locale: SupportedLocales) => {
     setI18n(locales[locale]);

--- a/ios/debtr/AppDelegate.m
+++ b/ios/debtr/AppDelegate.m
@@ -3,6 +3,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import "RNSplashScreen.h"
 
 #if DEBUG
 #import <FlipperKit/FlipperClient.h>
@@ -43,6 +44,7 @@ static void InitializeFlipper(UIApplication *application) {
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+  [RNSplashScreen showSplash:@"LaunchScreen" inRootView:rootView];
   return YES;
 }
 

--- a/src/configs/locales.ts
+++ b/src/configs/locales.ts
@@ -1,9 +1,9 @@
-import { name as enGBName } from "../i18n/en_GB";
-import { name as ptPTName } from "../i18n/pt_PT";
+import { name as enGBName } from "../i18n/en";
+import { name as ptPTName } from "../i18n/pt";
 
 import { SupportedLocales } from "../types";
 
 export const locales = [
-  { key: SupportedLocales.en_GB, name: enGBName, flag: ":gb:" },
-  { key: SupportedLocales.pt_PT, name: ptPTName, flag: ":flag-pt:" },
+  { key: SupportedLocales.en, name: enGBName, flag: ":gb:" },
+  { key: SupportedLocales.pt, name: ptPTName, flag: ":flag-pt:" },
 ];

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,10 +1,10 @@
 import { formatCurrency } from "../utils/formatters";
 import { SupportedCurrencies } from "../types";
 
-export const name = "English (U.K.)";
+export const name = "English";
 
 export default {
-  _locale: "en_GB",
+  _locale: "en",
   errTitle: "Error",
   errMsg: (err: string) => {
     return `An unexpected error ocurred retrieving your expenses. \n\nIf it persists contact support with the following message: \n\n${err}`;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,4 +1,4 @@
-import en_GB from "./en_GB";
-import pt_PT from "./pt_PT";
+import en from "./en";
+import pt from "./pt";
 
-export default { en_GB, pt_PT };
+export default { en, pt };

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -1,10 +1,10 @@
 import { SupportedCurrencies } from "../types";
 import { formatCurrency } from "../utils/formatters";
 
-export const name = "Português (Portugal)";
+export const name = "Português";
 
 export default {
-  _locale: "pt_PT",
+  _locale: "pt",
   errTitle: "Erro",
   errMsg: (err: string) => {
     return `Ocorreu um erro inesperado a obter as suas despesas. \n\nSe o problema persistir contacte-nos com a seguinte mensagem: \n\n${err}`;

--- a/src/screens/LocaleSelector.tsx
+++ b/src/screens/LocaleSelector.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function LocaleSelector({ onLocaleSelect }: Props) {
-  const [locale, setLocale] = useState(SupportedLocales.en_GB);
+  const [locale, setLocale] = useState(SupportedLocales.en);
 
   SplashScreen.hide();
 

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,4 +1,4 @@
-import i18nFile from "../i18n/en_GB";
+import i18nFile from "../i18n/en";
 
 export type I18n = typeof i18nFile;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,6 @@ export enum SupportedCurrencies {
 }
 
 export enum SupportedLocales {
-  en_GB = "en_GB",
-  pt_PT = "pt_PT",
+  en = "en",
+  pt = "pt",
 }


### PR DESCRIPTION
- added splashscreen handling for ios
- updated i18n to use just language (en. pt, etc) instead of language and country (en_GB, pt_PT, etc) for better UX